### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -10,7 +10,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - uses: elgohr/Publish-Docker-Github-Action@3.04
+            - uses: elgohr/Publish-Docker-Github-Action@v5
               with:
                   name: kdockerfiles/sndio
                   registry: ghcr.io


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore